### PR TITLE
record errors in tasks instead of just dumping a stack trace when found

### DIFF
--- a/pkg/examples/paralleltaskrunner_test.go
+++ b/pkg/examples/paralleltaskrunner_test.go
@@ -189,5 +189,65 @@ func RunParallelTaskRunnerTests() {
 				Expect(results["task-setkey-e"].Duration().Seconds()).Should(BeNumerically("~", 5, 0.1))
 			})
 		})
+
+		Describe("Error recording and handling", func() {
+			It("Errors hit at any stage of Task processing are attached to RunnerTask", func() {
+				a := tr.NewFunctionTask("a", func() error {
+					time.Sleep(2500 * time.Millisecond)
+					return errors.Errorf("a failed")
+				}, []tr.Task{}, []tr.Prereq{}, func() (bool, error) {
+					return false, nil
+				})
+				b := tr.NewFunctionTask("b", func() error {
+					return nil
+				}, []tr.Task{}, []tr.Prereq{}, func() (bool, error) {
+					time.Sleep(2500 * time.Millisecond)
+					return false, errors.Errorf("b isDone before failed")
+				})
+				cIsDone := false
+				c := tr.NewFunctionTask("c", func() error {
+					cIsDone = true
+					return nil
+				}, []tr.Task{}, []tr.Prereq{}, func() (bool, error) {
+					if !cIsDone {
+						return false, nil
+					}
+					time.Sleep(2500 * time.Millisecond)
+					return false, errors.Errorf("c isDone after failed")
+				})
+				dIsDone := false
+				d := tr.NewFunctionTask("d", func() error {
+					dIsDone = true
+					return nil
+				}, []tr.Task{}, []tr.Prereq{&tr.FunctionPrereq{
+					Name: "d-prereq",
+					Run: func() error {
+						time.Sleep(2500 * time.Millisecond)
+						return errors.Errorf("d prereq failed")
+					},
+				}}, func() (bool, error) {
+					return dIsDone, nil
+				})
+				group := tr.NewNoopTask("group", []tr.Task{a, b, c, d})
+
+				runner, err := tr.NewParallelTaskRunner(group, 5, 100)
+				Expect(err).To(Succeed())
+
+				time.Sleep(5 * time.Second)
+				runner.Stop() // ignore error
+				results := runner.Wait(context.TODO())
+
+				bytes, err := json.MarshalIndent(results, "", "  ")
+				Expect(err).To(Succeed())
+				fmt.Printf("%s\n\n", string(bytes))
+
+				Expect(results).To(HaveKey("group"))
+				// a,b,c,d all failed
+				for _, s := range []string{"a", "b", "c", "d"} {
+					Expect(results).To(HaveKey(s))
+					Expect(results[s].State).To(Equal(tr.TaskStateFailed))
+				}
+			})
+		})
 	})
 }

--- a/pkg/examples/paralleltaskrunner_test.go
+++ b/pkg/examples/paralleltaskrunner_test.go
@@ -246,6 +246,7 @@ func RunParallelTaskRunnerTests() {
 				for _, s := range []string{"a", "b", "c", "d"} {
 					Expect(results).To(HaveKey(s))
 					Expect(results[s].State).To(Equal(tr.TaskStateFailed))
+					fmt.Printf("%s: %s\n", s, results[s].Error.Error())
 				}
 			})
 		})

--- a/pkg/task-runner/task.go
+++ b/pkg/task-runner/task.go
@@ -64,22 +64,21 @@ func (ft *FunctionTask) TaskAddDependency(dep Task) {
 }
 
 func (ft *FunctionTask) TaskJSONObject() map[string]interface{} {
-	var deps []interface{}
+	var deps []string
 	for _, dep := range ft.Deps {
-		deps = append(deps, dep.TaskJSONObject())
+		deps = append(deps, dep.TaskName())
 	}
 	var prereqs []string
 	for _, p := range ft.Prereqs {
 		prereqs = append(prereqs, p.PrereqName())
 	}
-	dict := map[string]interface{}{
+	return map[string]interface{}{
 		"Run":          "[function]",
 		"Dependencies": deps,
 		"IsDone":       "[function]",
 		"Prereqs":      prereqs,
 		"Name":         ft.Name,
 	}
-	return dict
 }
 
 func (ft *FunctionTask) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
Allow the caller to decide what to do with errors.